### PR TITLE
fix: improve SECRET_KEY error in main repo

### DIFF
--- a/.github/workflows/djangoCI.yml
+++ b/.github/workflows/djangoCI.yml
@@ -28,7 +28,7 @@ jobs:
       
       - name: Run tests
         env:
-          SECRET_KEY : ${{ secrets.SECRET_KEY }}
+          SECRET_KEY : secret
         run: |
           make test
 


### PR DESCRIPTION
В файле .github/workflows/djangoCI.yml исправил строку 31 на:
 SECRET_KEY : secret
Подсмотрел в проекте hexlet-friends, ошибка  The SECRET_KEY setting must not be empty должна пропасть, у меня в репозитории тесты запустились и успешно прошли)